### PR TITLE
fix: refresh social preview image metadata (#35)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://jeffdoolittle.com/sitemap-index.xml

--- a/src/components/PostGrid.astro
+++ b/src/components/PostGrid.astro
@@ -14,7 +14,7 @@ const { posts } = Astro.props;
     <div class="post-card">
       {post.data.image && (
         <a href={postUrl(post)} class="post-card__img-link">
-          <img class="post-card__img" src={post.data.image} alt={post.data.image_alt || post.data.title} loading="lazy" />
+          <img class="post-card__img" src={post.data.image} alt={post.data.image_alt || post.data.title} loading="lazy" decoding="async" fetchpriority="low" />
         </a>
       )}
       <div class="post-card__body">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -77,16 +77,17 @@ const navLinks = [
   <link rel="stylesheet" href="/main.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sora:wght@600;700;800&display=swap" rel="stylesheet" />
-
-  <!-- Lightbox CSS -->
-  <link rel="stylesheet" href="/lightbox.css" />
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sora:wght@600;700;800&display=swap" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sora:wght@600;700;800&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+  <noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Sora:wght@600;700;800&display=swap" rel="stylesheet" />
+  </noscript>
 
   <!-- RSS Feed -->
   <link rel="alternate" type="application/rss+xml" title="Jeff Doolittle" href="/feed.xml" />
 
   <!-- Font Awesome -->
-  <script src="https://kit.fontawesome.com/2202cfd9ba.js" crossorigin="anonymous" is:inline></script>
+  <script src="https://kit.fontawesome.com/2202cfd9ba.js" crossorigin="anonymous" defer is:inline></script>
 
   <GoogleAnalytics />
 </head>
@@ -240,9 +241,31 @@ const navLinks = [
     </div>
   </footer>
 
-  <!-- jQuery + Lightbox -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" is:inline></script>
-  <script is:inline src="/lightbox.js"></script>
+  <script is:inline>
+    (function() {
+      // Load lightbox assets only on pages that have likely lightbox/embed targets.
+      var hasLightboxTargets = !!document.querySelector(
+        '.lightbox-image, a[href*="youtube.com"], a[href*="youtu.be"], a[href*="vimeo.com"], a[href$=".jpg"], a[href$=".jpeg"], a[href$=".png"], a[href$=".gif"], a[href$=".svg"]'
+      );
+      if (!hasLightboxTargets) return;
+
+      var css = document.createElement('link');
+      css.rel = 'stylesheet';
+      css.href = '/lightbox.css';
+      document.head.appendChild(css);
+
+      var jquery = document.createElement('script');
+      jquery.src = 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js';
+      jquery.defer = true;
+      jquery.onload = function() {
+        var lightbox = document.createElement('script');
+        lightbox.src = '/lightbox.js';
+        lightbox.defer = true;
+        document.body.appendChild(lightbox);
+      };
+      document.body.appendChild(jquery);
+    })();
+  </script>
 
 </body>
 </html>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -12,7 +12,7 @@ interface Props {
 const {
   title,
   description = "Software Architect. Strategic Business Leader. I help make good software professionals great!",
-  image = "/assets/og_image.png",
+  image = "/assets/social_head_shot.jpg",
   canonicalUrl,
 } = Astro.props;
 
@@ -57,6 +57,12 @@ const navLinks = [
   <meta property="og:description" content={description} />
   <meta property="og:image" content={image} />
   <meta property="og:type" content="website" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={pageTitle} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={image} />
 
   {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
 

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -14,7 +14,7 @@ const recentPosts = allPosts
   <section class="hero">
     <div class="hero__inner">
       <div class="hero__avatar">
-        <img src="/assets/circle_head_shot_2025_small.png" alt="Jeff Doolittle" />
+        <img src="/assets/circle_head_shot_2025_small.png" alt="Jeff Doolittle" decoding="async" fetchpriority="high" />
       </div>
       <h1 class="hero__title">Jeff Doolittle</h1>
       <p class="hero__tagline">
@@ -77,7 +77,7 @@ const recentPosts = allPosts
     </div>
 
     <div class="small-banner wrapper">
-      <img src="/assets/circle_head_shot_2025_small.png" />
+      <img src="/assets/circle_head_shot_2025_small.png" loading="lazy" decoding="async" />
     </div>
   </div>
 </Base>


### PR DESCRIPTION
## Summary
- update default social image to /assets/social_head_shot.jpg
- add explicit Twitter card tags using same image

Closes #35.